### PR TITLE
Vuex Type Helper をシンプルなかたちで利用する

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -21,29 +21,21 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'nuxt-property-decorator'
-import * as counter from '~/store/counter'
-// import { Actions } from '~/types/counter'
+import { Component, Vue, namespace } from 'nuxt-property-decorator'
 import Logo from '~/components/Logo.vue'
+
+const counter = namespace('counter')
 
 @Component({
   components: {
     Logo
-  },
-  computed: {
-    ...counter.mapGetters(['half'])
-  },
-  methods: {
-    ...counter.mapActions(['incrementAsync'])
   }
 })
 export default class IndexPage extends Vue {
-  // error  Parsing error: Unexpected token, expected "]"
-  // incrementAsync: (payload: Actions['incrementAsync']) => void
-  incrementAsync: (payload: any) => void
+  @counter.Getter('half') half
+  @counter.Action('incrementAsync') incrementAsync
 
   increment(): void {
-    console.log(counter)
     this.incrementAsync({ amount: 1, delay: 1000 })
   }
 }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -21,10 +21,8 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, namespace } from 'nuxt-property-decorator'
+import { Component, Getter, Vue } from 'nuxt-property-decorator'
 import Logo from '~/components/Logo.vue'
-
-const counter = namespace('counter')
 
 @Component({
   components: {
@@ -32,11 +30,10 @@ const counter = namespace('counter')
   }
 })
 export default class IndexPage extends Vue {
-  @counter.Getter('half') half
-  @counter.Action('incrementAsync') incrementAsync
+  @Getter('counter/half') half
 
   increment(): void {
-    this.incrementAsync({ amount: 1, delay: 1000 })
+    this.$store.dispatch('counter/incrementAsync', { amount: 1, delay: 1000 })
   }
 }
 </script>

--- a/src/store/counter.ts
+++ b/src/store/counter.ts
@@ -1,6 +1,4 @@
-import { createNamespacedHelpers } from 'vuex'
 import { DefineGetters, DefineMutations, DefineActions } from 'vuex-type-helper'
-import { Actions } from '~/types/counter'
 
 interface State {
   count: number
@@ -13,6 +11,13 @@ interface Getters {
 interface Mutations {
   increment: {
     amount: number
+  }
+}
+
+export interface Actions {
+  incrementAsync: {
+    amount: number
+    delay: number
   }
 }
 
@@ -42,13 +47,3 @@ export const actions: DefineActions<
     }, payload.delay)
   }
 }
-
-export const {
-  mapGetters,
-  mapActions
-} = createNamespacedHelpers<
-  State,
-  Getters,
-  Mutations,
-  Actions
->('counter')

--- a/src/types/counter.d.ts
+++ b/src/types/counter.d.ts
@@ -1,6 +1,0 @@
-export interface Actions {
-  incrementAsync: {
-    amount: number
-    delay: number
-  }
-}


### PR DESCRIPTION
store/*.ts 内では型安全にするが、コンポーネントから利用する際は型を諦める